### PR TITLE
feat: count bits in 32-bit word

### DIFF
--- a/experiment5.asm
+++ b/experiment5.asm
@@ -3,22 +3,22 @@
         ENTRY
 
 _start
-        LDR     r0, =DATA      ; byte to inspect
-        LDRB    r0, [r0]
-        MOV     r1, #0         ; ones
-        MOV     r2, #0         ; zeros
-        MOV     r3, #8         ; bit counter
+        LDR     r0, =DATA      ; 32-bit value to inspect
+        LDR     r0, [r0]
+        MOV     r1, #0         ; count of ones
+        MOV     r3, #32        ; bit counter
 
 bit_loop
-        RRX     r0, r0         ; shift right through carry
-        ADDCS   r1, r1, #1     ; carry set => bit was 1
-        ADDCC   r2, r2, #1     ; carry clear => bit was 0
+        LSRS    r0, r0, #1     ; shift right, LSB into carry
+        ADCS    r1, r1, #0     ; accumulate ones from carry
         SUBS    r3, r3, #1
         BNE     bit_loop
 
-        ; verify ones + zeros = 8
+        RSB     r2, r1, #32    ; zeros = 32 - ones
+
+        ; verify ones + zeros = 32
         ADD     r4, r1, r2
-        CMP     r4, #8
+        CMP     r4, #32
         MOVEQ   r5, #1
         MOVNE   r5, #0
 
@@ -34,7 +34,7 @@ stop
         B       stop
 
         ALIGN
-DATA    DCB 0xAC
+DATA    DCD 0x12345678
 ONES    DCD 0
 ZEROS   DCD 0
 PASS    DCD 0


### PR DESCRIPTION
## Summary
- extend bit counting routine to support 32-bit values
- compute zero bits and verification against 32-bit width

## Testing
- `arm-none-eabi-as -g experiment5.asm -o experiment5.o` *(fails: Assembler messages: ... bad instruction `area EXP5,CODE,READONLY`)*

------
https://chatgpt.com/codex/tasks/task_e_68c69d6e39d88331ab98d150605e0ba8